### PR TITLE
Fixed Windows specific path problem on Unix Systems.

### DIFF
--- a/Java/src/implementation/Main.java
+++ b/Java/src/implementation/Main.java
@@ -36,7 +36,7 @@ public class Main {
 	public static void main(String[] args) throws IOException, InstantiationException, IllegalAccessException, ClassNotFoundException{
 		Path currentRelativePath = Paths.get("");	
 
-		String quotes = currentRelativePath.toAbsolutePath().toString() + "\\data";
+		String quotes = currentRelativePath.resolve("data").toAbsolutePath().toString();
 
 	try{			
 			Path path = Paths.get(quotes);


### PR DESCRIPTION
Using backslashes in paths only works on Windows systems. Fixed it to
work on all systems.